### PR TITLE
Bump reqwest version to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Dan Čermák <dcermak@suse.com>"]
 edition = "2018"
 
 [dependencies]
-reqwest = "0.9"
+reqwest = { version = "0.10", features = ["blocking", "json"] }
 serde = "1"
 failure = "0.1"
 serde_json = "1"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -106,14 +106,15 @@ struct VagrantCloudErrorPayload {
     success: bool,
 }
 
-impl From<reqwest::Response> for Error {
+impl From<reqwest::blocking::Response> for Error {
     /// Create a [`Error`](enum.Error.html) from a `reqwest::Response`
-    fn from(mut resp: reqwest::Response) -> Error {
+    fn from(resp: reqwest::blocking::Response) -> Error {
+        let status = resp.status();
         let msg: reqwest::Result<VagrantCloudErrorPayload> = resp.json();
         let err_msg: String = match msg {
             Ok(rpl) => rpl.errors.join(", "),
             Err(_) => "".to_string(),
         };
-        Error::ApiCallFailure(resp.status(), err_msg)
+        Error::ApiCallFailure(status, err_msg)
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -76,7 +76,7 @@ fn compare_boxes() {
 #[test]
 fn error_conversion_from_reqwest_error() {
     let url = &URL.to_string();
-    let res = reqwest::get(url);
+    let res = reqwest::blocking::get(url);
 
     assert!(res.is_err());
     let err_msg = format!("{}", res.as_ref().unwrap_err());
@@ -97,7 +97,7 @@ fn error_conversion_from_malformed_request_result() {
         .with_body("{}")
         .create();
 
-    let res = reqwest::get(&mockito::server_url());
+    let res = reqwest::blocking::get(&mockito::server_url());
 
     assert!(res.is_ok());
 
@@ -124,7 +124,7 @@ fn error_conversion_from_vagrantcloud_error_request_result() {
         )
         .create();
 
-    let res = reqwest::get(&mockito::server_url());
+    let res = reqwest::blocking::get(&mockito::server_url());
 
     assert!(res.is_ok());
 


### PR DESCRIPTION
json & blocking are now required for vagabond, as it needs both (async is currently not yet worth it)